### PR TITLE
Force 1.3.5 to rebuild for linux

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   skip: true  # [py<37]
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Ensured the license file is being packaged.

<!--
Please add any other relevant info below:
-->
Version 1.3.5 was built yesterday while quay.io was being flaky. Linux passed in the PR checks, but subsequently failed after merging, leaving linux builds stuck at 1.3.4.

This PR bumps the build number to attempt to build for linux again. No other changes exist.